### PR TITLE
Remove un-needed check for PFSystem

### DIFF
--- a/3DSMax/AlembicPoints.cpp
+++ b/3DSMax/AlembicPoints.cpp
@@ -311,7 +311,7 @@ bool AlembicPoints::Save(double time, bool bLastFrame)
       }
       else
 #endif
-          if (particlesExt && ipfSystem) {
+      if (particlesExt) {
 
         TimeValue ageValue = particlesExt->GetParticleAgeByIndex(i);
         if (ageValue == -1) {


### PR DESCRIPTION
If not Thinking Particles, there is no need to check for both the ext particle interface and ipfSystem - in PhoenixFD we had to create a dummy PFSystem in order to workaround this limitation. The actual ipfSystem is checked before actually being used about 20 lines further.
