### PR TITLE
Guarded unchecked pointers during particle export

### DIFF
--- a/3DSMax/AlembicPoints.cpp
+++ b/3DSMax/AlembicPoints.cpp
@@ -571,6 +571,9 @@ Abc::C4f AlembicPoints::GetColor(IParticleObjectExt *pExt, int particleId,
   }
 
   IParticleGroup *particleGroup = GetParticleGroupInterface(particleGroupObj);
+  if (!particleGroup) {
+    return color;
+  }
   INode *particleActionListNode = particleGroup->GetActionList();
   Object *particleActionObj =
       (particleActionListNode != NULL
@@ -836,6 +839,10 @@ void AlembicPoints::GetShapeType(IParticleObjectExt *pExt, int particleId,
   }
 
   IParticleGroup *particleGroup = GetParticleGroupInterface(particleGroupObj);
+  if (!particleGroup) {
+    return;
+  }
+  
   INode *particleActionListNode = particleGroup->GetActionList();
   Object *particleActionObj =
       (particleActionListNode != NULL


### PR DESCRIPTION
The built-in 3ds max Alembic export forces us at PhoenixFD to provide a dummy node as a result of GetParticleGroup() in order for the export to proceed correctly. This is why the returned node does not have to necessarily implement the IParticleGroup interface and should better be checked against NULL.
